### PR TITLE
Add `Render<T>` implementation for `Fn(&T) -> Cow<str>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+- New implementation of `Render<T>` for any type which is `for<'a> Fn(&'a T) -> Cow<'a, str>`.
+
 ## [0.6.0] - 2024-12-01
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,15 @@ use crate::{
 ///
 /// Some renderers for common types are already implemented in the [`render`] module. In
 /// many cases, the [`DisplayRenderer`](render::DisplayRenderer) is particularly easy to use.
+/// This trait is also automatically implemented for [closures which return `Cow<'a,
+/// str>`](#impl-Render<T>-for-R).
 ///
-/// Rendering *must* be **idempotent**: for a given render implementation `R` and a item `T`, the call
+/// Rendering *must* be **pure**: for a given render implementation `R` and a item `T`, the call
 /// `R::render(&self, &T)` must depend only on the specific render instance and the specific item,
-/// and not any other mutable state. Violation of this condition is normally only possible via
-/// interior mutability, global state, I/O, or unsafe code.
+/// and not any other state. Violation of this condition is normally only possible via interior
+/// mutability, global state, I/O, or unsafe code.
 ///
-/// If idempotence is violated, internal index computations which depend on the rendered format
+/// If purism is violated, internal index computations which depend on the rendered format
 /// will become invalid and the picker may either panic or return incorrect results. Note that such
 /// errors are encapsulated within the picker and will not result in undefined behaviour.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod render;
 mod term;
 
 use std::{
+    borrow::Cow,
     io::{self, IsTerminal},
     iter::Extend,
     num::NonZero,
@@ -198,6 +199,17 @@ pub trait Render<T> {
     /// Render the given item as it should appear in the picker. See the
     /// [trait-level docs](Render) for more detail.
     fn render<'a>(&self, item: &'a T) -> Self::Str<'a>;
+}
+
+impl<T, R: for<'a> Fn(&'a T) -> Cow<'a, str>> Render<T> for R {
+    type Str<'a>
+        = Cow<'a, str>
+    where
+        T: 'a;
+
+    fn render<'a>(&self, item: &'a T) -> Self::Str<'a> {
+        self(item)
+    }
 }
 
 /// Specify configuration options for a [`Picker`].


### PR DESCRIPTION
This PR adds a `Render<T>` implementation for any implementation of `for<'a> Fn(&'a T) -> Cow<'a, str>`. In an ideal world, we would actually like automatic implementations for the other types such as `Fn(&T) -> String` or `Fn(&T) -> &str` but this is not possible because of conflicting trait implementations. Maybe we would even like something more general like `Fn(&'a T) -> S where S: AsRef<str>` but the problem is that then the caller cannot take advantage of lifetimes.

My general feeling that the concrete return type of `Cow<'a, str>` is the best for most applications, and with inlining if you always construct `Cow::Owned(String)` or `Cow::Borrowed(&str)` the compiler will probably just delete the `Cow` anyway.