### PR TITLE
Do not lock `stdin()` in fzf example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,7 @@ cat myfile.txt | ./target/release/examples/fzf
 ```
 The code to create the binary:
 ```rust
-use std::{
-    io::{self, BufRead},
-    process::exit,
-    thread::spawn,
-};
+use std::{io, process::exit, thread::spawn};
 
 use nucleo_picker::{render::StrRenderer, Picker};
 
@@ -56,7 +52,7 @@ fn main() -> io::Result<()> {
 
     let injector = picker.injector();
     spawn(move || {
-        for line in io::stdin().lock().lines() {
+        for line in io::stdin().lines() {
             if let Ok(s) = line {
                 injector.push(s);
             }

--- a/examples/fzf.rs
+++ b/examples/fzf.rs
@@ -2,11 +2,7 @@
 //!
 //! Read lines from `stdin` in a streaming fashion and populate the picker, imitating the basic
 //! functionality of [fzf](https://github.com/junegunn/fzf).
-use std::{
-    io::{self, BufRead},
-    process::exit,
-    thread::spawn,
-};
+use std::{io, process::exit, thread::spawn};
 
 use nucleo_picker::{render::StrRenderer, Picker};
 
@@ -15,7 +11,7 @@ fn main() -> io::Result<()> {
 
     let injector = picker.injector();
     spawn(move || {
-        for line in io::stdin().lock().lines() {
+        for line in io::stdin().lines() {
             // silently drop IO errors!
             if let Ok(s) = line {
                 injector.push(s);


### PR DESCRIPTION
For some reason, on mac (and maybe other platforms), even with the `use-dev-tty` feature enabled in `crossterm`, the terminal does not process STDIN correctly when stdin is locked if running with no input (i.e. `cargo run --example fzf`, without piping anything in).

This PR just removes the lock so that things work as expected even with no input.