### PR TITLE
Check for interactive stdin in fzf example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ cat myfile.txt | ./target/release/examples/fzf
 ```
 The code to create the binary:
 ```rust
-use std::{io, process::exit, thread::spawn};
+use std::{
+    io::{self, IsTerminal},
+    process::exit,
+    thread::spawn,
+};
 
 use nucleo_picker::{render::StrRenderer, Picker};
 
@@ -52,9 +56,13 @@ fn main() -> io::Result<()> {
 
     let injector = picker.injector();
     spawn(move || {
-        for line in io::stdin().lines() {
-            if let Ok(s) = line {
-                injector.push(s);
+        let stdin = io::stdin();
+        if !stdin.is_terminal() {
+            for line in stdin.lines() {
+                // silently drop IO errors!
+                if let Ok(s) = line {
+                    injector.push(s);
+                }
             }
         }
     });

--- a/examples/fzf.rs
+++ b/examples/fzf.rs
@@ -2,7 +2,11 @@
 //!
 //! Read lines from `stdin` in a streaming fashion and populate the picker, imitating the basic
 //! functionality of [fzf](https://github.com/junegunn/fzf).
-use std::{io, process::exit, thread::spawn};
+use std::{
+    io::{self, IsTerminal},
+    process::exit,
+    thread::spawn,
+};
 
 use nucleo_picker::{render::StrRenderer, Picker};
 
@@ -11,10 +15,13 @@ fn main() -> io::Result<()> {
 
     let injector = picker.injector();
     spawn(move || {
-        for line in io::stdin().lines() {
-            // silently drop IO errors!
-            if let Ok(s) = line {
-                injector.push(s);
+        let stdin = io::stdin();
+        if !stdin.is_terminal() {
+            for line in stdin.lines() {
+                // silently drop IO errors!
+                if let Ok(s) = line {
+                    injector.push(s);
+                }
             }
         }
     });


### PR DESCRIPTION
Unfortunately #45 was not enough; now we also check that stdin is not interactive in the `fzf` example.