### PR TITLE
Prune error constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["cli"]
 license = "MIT OR Apache-2.0"
 name = "nucleo-picker"
 repository = "https://github.com/autobib/nucleo-picker"
-version = "0.7.0-alpha.0"
+version = "0.7.0-alpha.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,8 +3,8 @@
 //! This module defines the core [`Event`] type handled by a [`Picker`](crate::Picker), which
 //! defines an interactive update to the picker state.
 //!
-//! By default, the [`Picker::pick`](crate::Picker::pick) reads events from the terminal and maps
-//! those events to [`Event`]s. The process of reading events is encapsulated in the
+//! By default, the [`Picker::pick`](crate::Picker::pick) watches for terminal events (such as key
+//! presses) and maps them to [`Event`]s. The process of reading events is encapsulated in the
 //! [`EventSource`] trait, which you can implement yourself and pass directly to the picker using
 //! the [`Picker::pick_with_io`](crate::Picker::pick_with_io).
 //!
@@ -12,9 +12,11 @@
 //! - The [`EventSource`] trait.
 //! - The [`StdinReader`], for automatically reading events from standard input, with customizable
 //!   keybindings.
-//! - The [default keybindings](keybind_default)
+//! - The [`StdinEventSender`] to read events from standard input and send them through a
+//!  [mpsc channel](std::sync::mpsc::channel).
+//! - The [default keybindings](keybind_default).
 //!
-//! For a more comprehensive example, visit the [extended fzf
+//! For a somewhat comprehensive example, see the [extended fzf
 //! example](https://github.com/autobib/nucleo-picker/blob/master/examples/fzf_err_handling.rs) on GitHub.
 
 mod bind;

--- a/src/event/bind.rs
+++ b/src/event/bind.rs
@@ -1,5 +1,3 @@
-use std::error::Error as StdError;
-
 use crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use super::{Event, MatchListEvent, PromptEvent};
@@ -17,9 +15,7 @@ use super::{Event, MatchListEvent, PromptEvent};
 /// here for flexibility to generate events of a particular type when used in situations where `A`
 /// is not the default `!`.
 #[inline]
-pub fn keybind_default<A: StdError + Send + Sync + 'static>(
-    key_event: KeyEvent,
-) -> Option<Event<A>> {
+pub fn keybind_default<A>(key_event: KeyEvent) -> Option<Event<A>> {
     match key_event {
         KeyEvent {
             kind: KeyEventKind::Press,
@@ -88,10 +84,7 @@ pub fn keybind_default<A: StdError + Send + Sync + 'static>(
 }
 
 /// Convert a crossterm event into an [`Event`], mapping key events with the giving key bindings.
-pub fn convert_crossterm_event<
-    A: StdError + Send + Sync + 'static,
-    F: Fn(KeyEvent) -> Option<Event<A>>,
->(
+pub fn convert_crossterm_event<A, F: Fn(KeyEvent) -> Option<Event<A>>>(
     ct_event: CrosstermEvent,
     keybind: F,
 ) -> Option<Event<A>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ mod util;
 
 use std::{
     borrow::Cow,
-    error::Error as StdError,
     io::{self, BufWriter, IsTerminal, Write},
     iter::Extend,
     num::NonZero,
@@ -711,7 +710,6 @@ impl<T: Send + Sync + 'static, R: Render<T>> Picker<T, R> {
         writer: &mut W,
     ) -> Result<Option<&T>, PickError<A>>
     where
-        A: StdError + Send + Sync + 'static,
         E: EventSource<AbortErr = A>,
         W: io::Write,
     {


### PR DESCRIPTION
We don't actually need the error type to be `StdError + Send + Sync + 'static` except in certain situations so we can just remove all of the trait bounds.