### PR TITLE
Implement interactive restarting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Reset selection using `ctrl + r`.
 - New `PickerOptions::frame_interval` option to customize the refresh rate of the picker.
+- Reversed rendering with `PickerOptions::reversed`
 - New `Picker::pick_with_io` and `Picker::pick_with_keybind` functions that allows much greater IO customization.
   - Provide your own `Writer`.
   - Customize keybindings using a `StdinReader`.
   - Drive the picker using a `mpsc` channel.
   - Propagate custom errors to the picker from other threads.
   - Implement your own `EventSource` for total customization.
-- New examples to demonstrate the new IO customization:
+  - Interactively restart the picker with new items.
+- New examples to demonstrate the `Event` system
   - `custom_io` for a basic example
   - `fzf_err_handling` to use channels for event propagation
-- Reversed rendering with `PickerOptions::reversed`
+  - `restart` to demonstrate interactive restarting (with extended example `restart_ext`)
 
 ### Deprecated
 - `PickerOptions::query` has been renamed to `PickerOptions::prompt` for naming consistency.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ name = "find"
 name = "restart"
 
 [[example]]
+name = "restart_ext"
+
+[[example]]
 name = "blocking"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 crossbeam = "0.8.4"
+rand = "0.8.5"
 ignore = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -41,6 +42,9 @@ name = "fzf_err_handling"
 
 [[example]]
 name = "find"
+
+[[example]]
+name = "restart"
 
 [[example]]
 name = "blocking"

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Why use this library instead of a general-purpose fuzzy-finder such as `fzf` or 
    Instead of reading from a SQLite database with `sqlite3` and then parsing raw text, read directly into in-memory data structures with [`rusqlite`](https://docs.rs/rusqlite/latest/rusqlite/) and render the in-memory objects in the picker.
 2. **Skip the subprocess overhead and improve startup time.**
    Instead of starting up a subprocess to call `fzf`, have the picker integrated directly into your binary.
-2. **Distinguish items from their matcher representation.**
+3. **Distinguish items from their matcher representation.**
    Instead of writing your data structure to a string, passing it to `fzf`, and then parsing the resulting match string back into your data structure, directly obtain the original data structure when matching is complete.
-3. **Don't spend time debugging terminal rendering edge cases.**
+4. **Don't spend time debugging terminal rendering edge cases.**
    Out-of-the-box, `nucleo-picker` handles terminal rendering subtleties such as *multiline rendering*, *double-width Unicode*, *automatic overflow scrollthrough*, and *grapheme-aware query input* so you don't have to.
 
 ## Features
@@ -27,12 +27,16 @@ Why use this library instead of a general-purpose fuzzy-finder such as `fzf` or 
 - Robust rendering:
   - Full Unicode handling with [Unicode text segmentation](https://crates.io/crates/unicode-segmentation) and [Unicode width](https://crates.io/crates/unicode-width).
   - Match highlighting with automatic scroll-through.
-  - Correctly render multi-line or overflowed items.
+  - Correctly render multi-line or overflowed items, with standard and reversed item order.
   - Responsive interface with batched keyboard input.
 - Ergonomic API:
   - Fully concurrent lock- and wait-free streaming of input items.
   - Generic `Picker` for any type `T` which is `Send + Sync + 'static`.
   - Customizable rendering of crate-local and foreign types with the `Render` trait.
+- Fully configurable event system:
+  - Easily customizable keybindings.
+  - Run the picker concurrently with a your application using a flexible `Event` system supporting standard picker operations, along with more complex features such as *interactive restarting*.
+  - Flexible error propagation generics so your application errors can interface cleanly with the picker.
 
 ## Example
 Implement a heavily simplified `fzf` clone in 25 lines of code.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,12 +11,14 @@ Some of the examples may require arguments or feature flags to run properly; see
 
 ## Directory
 
-File                          | Description
-------------------------------|------------
-[blocking.rs](blocking.rs)    | A basic blocking example with a very small number of matches.
-[custom_io.rs](custom_io.rs)  | Customize IO with keybindings and alternative writer.
-[find.rs](find.rs)            | A basic [find](https://en.wikipedia.org/wiki/Find_(Unix)) implementation with fuzzy matching on resulting items.
-[fzf.rs](fzf.rs)              | A simple [fzf](https://github.com/junegunn/fzf) clone which reads lines from STDIN and presents for matching.
-[fzf_err_handling.rs](fzf.rs) | An improved version of the `fzf` example using channels to propagate read errors.
-[options.rs](options.rs)      | Some customization examples of the picker.
-[serde.rs](serde.rs)          | Use `serde` to deserialize picker items from input.
+File                             | Description
+---------------------------------|-------------
+[blocking.rs](blocking.rs)       | A basic blocking example with a very small number of matches.
+[custom_io.rs](custom_io.rs)     | Customize IO with keybindings and alternative writer.
+[find.rs](find.rs)               | A basic [find](https://en.wikipedia.org/wiki/Find_(Unix)) implementation with fuzzy matching on resulting items.
+[fzf.rs](fzf.rs)                 | A simple [fzf](https://github.com/junegunn/fzf) clone which reads lines from STDIN and presents for matching.
+[fzf_err_handling.rs](fzf.rs)    | An improved version of the `fzf` example using channels to propagate read errors.
+[options.rs](options.rs)         | Some customization examples of the picker.
+[restart.rs](restart.rs)         | Demonstration of interactive restarting in response to user input.
+[restart_ext.rs](restart_ext.rs) | An extended version of the restart example.
+[serde.rs](serde.rs)             | Use `serde` to deserialize picker items from input.

--- a/examples/custom_io.rs
+++ b/examples/custom_io.rs
@@ -9,7 +9,7 @@ use nucleo_picker::{
 
 /// Keybindings which use the default keybindings, but instead of aborting on `ctrl + c`,
 /// simply perform a normal quit action.
-fn keybind_no_interrupt(key_event: KeyEvent) -> Option<Event> {
+fn keybind_no_interrupt<T, R>(key_event: KeyEvent) -> Option<Event<T, R>> {
     match key_event {
         KeyEvent {
             kind: KeyEventKind::Press,

--- a/examples/fzf_err_handling.rs
+++ b/examples/fzf_err_handling.rs
@@ -39,7 +39,7 @@ fn main() -> io::Result<()> {
     }
 
     // create a new channel. The `sender` end is used to send `Event`s to the picker, and the
-    // `receiver` end is passed directly to the picker so that it can receiv the corresponding
+    // `receiver` end is passed directly to the picker so that it can receive the corresponding
     // events
     let (sender, receiver) = channel();
 
@@ -77,8 +77,9 @@ fn main() -> io::Result<()> {
                         // if we encounter an IO error, we send the corresponding error
                         // to the picker so that it can abort and propogate the error
                         //
-                        // here, it is also safe to simply ignore the IO error since the picker will
-                        // remain interactive with the items it has already received.
+                        // alternatively, it would also be safe to simply ignore the IO error
+                        // since the picker will remain interactive with the items it has
+                        // already received.
                         let _ = sender.send(Event::Abort(AppError::Stdin(io_err)));
                         return;
                     }

--- a/examples/restart.rs
+++ b/examples/restart.rs
@@ -1,0 +1,82 @@
+//! # Picker with interactive restarts
+//!
+//! Generates a list of 100 random `u32`s to be selected. The user can either select
+//! one of the options, or press `ctrl + n` to receive a new list of random integers.
+
+use std::{
+    io::{self, IsTerminal},
+    process::exit,
+    sync::mpsc::sync_channel,
+    thread::spawn,
+};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use nucleo_picker::{
+    event::{keybind_default, Event, StdinReader},
+    render::DisplayRenderer,
+    Picker,
+};
+use rand::{distributions::Standard, thread_rng, Rng};
+
+fn main() -> io::Result<()> {
+    let mut picker: Picker<u32, _> = Picker::new(DisplayRenderer);
+
+    // initialize stderr and check that we can actually write to the screen
+    let mut stderr = io::stderr().lock();
+    if !stderr.is_terminal() {
+        eprintln!("Failed to start picker: STDERR not interactive!");
+        exit(1);
+    }
+
+    // Create a thread to regenerate the number list in response to 'restart' events.
+    //
+    // Generating 100 random `u32`s is extremely fast so we do not need to worry about keeping
+    // up with restart events. For slower and more resource-intensive event generation, in
+    // practice one would regularly check the channel using `receiver.try_recv` for new
+    // restart events while feeding the picker with items to check if the current computation
+    // should be halted and restarted on a new injector.
+    let (sync_sender, receiver) = sync_channel(8);
+
+    // immediately send an injector down the channel so that the screen renders with some choices;
+    // this is infallible since we know that the receiver has not yet been dropped at this point
+    let _ = sync_sender.send(picker.injector());
+
+    spawn(move || {
+        let mut rng = thread_rng();
+
+        // block when waiting for new events, since we have nothing else to do. If the match does
+        // not succeed, it means the channel dropped so we can shut down this thread.
+        while let Ok(mut injector) = receiver.recv() {
+            // the restart event here is an injector for the picker; send the new items to the
+            // injector every time we witness the event
+            injector.extend((&mut rng).sample_iter(Standard).take(100));
+        }
+    });
+
+    // Initialize a source to watch for keyboard events.
+    //
+    // It would also be possible to generate the new events directly inside the closure,
+    // instead of passing the events to a separate thread. However, if generating new
+    // items were to take a long time, we do not want to lag user input and block watching
+    // for new keyboard events. In this specific example, it would be fine.
+    let event_source = StdinReader::new(move |key_event: KeyEvent| match key_event {
+        KeyEvent {
+            kind: KeyEventKind::Press,
+            modifiers: KeyModifiers::CONTROL,
+            code: KeyCode::Char('n'),
+            ..
+        } => Some(Event::Restart::<_, _>(sync_sender.clone())),
+        e => keybind_default(e),
+    });
+
+    match picker.pick_with_io(event_source, &mut stderr)? {
+        Some(num) => {
+            println!("Your favourite number is: {num}");
+            Ok(())
+        }
+        None => {
+            println!("You didn't like any of the numbers!");
+            exit(1);
+        }
+    }
+}

--- a/examples/restart_ext.rs
+++ b/examples/restart_ext.rs
@@ -1,0 +1,119 @@
+//! # Picker with interactive restarts and slow event generation
+//!
+//! Generates a list of 1000 random `u32`s to be selected but with intentionally introduced delay
+//! to imitate 'work' being done in the background.
+//!
+//! The user can either select one of the options, or press `ctrl + n` to receive a new list of
+//! random integers. Try pressing `ctrl + n` very rapidly; new numbers will be generated even before
+//! the previous list has finished rendering.
+//!
+//! This is a more complex version of the `restart` example; it is better to start there first. The
+//! only documentation here is for the changes relative to the `restart` example.
+
+use std::{
+    io::{self, IsTerminal},
+    process::exit,
+    sync::mpsc::{sync_channel, TryRecvError},
+    thread::sleep,
+    thread::spawn,
+    time::Duration,
+};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use nucleo_picker::{
+    event::{keybind_default, Event, StdinReader},
+    render::DisplayRenderer,
+    Picker,
+};
+use rand::random;
+
+/// Generate a random `u32` but with a lot of extra delay to imitate an expensive computation.
+fn slow_random() -> u32 {
+    sleep(Duration::from_millis(5));
+    random()
+}
+
+fn main() -> io::Result<()> {
+    let mut picker: Picker<u32, _> = Picker::new(DisplayRenderer);
+
+    let mut stderr = io::stderr().lock();
+    if !stderr.is_terminal() {
+        eprintln!("Failed to start picker: STDERR not interactive!");
+        exit(1);
+    }
+
+    let (sync_sender, receiver) = sync_channel::<nucleo_picker::Injector<u32, _>>(8);
+
+    let injector = picker.injector();
+    spawn(move || {
+        const NUM_ITEMS: usize = 1000;
+
+        // because of the delay, generating 1000 `u32`s will take about 5 seconds, which is clearly
+        // way too long to be done in a single frame. Therefore after generating each random number
+        // we check for a restart event before continuing.
+
+        // In this example, coming up with the check frequency is quite easy since we know the
+        // delay is 5ms, which is approximately the frame interval. In practice, with
+        // computation-heavy item generation, tuning the check frequency to happen approximately
+        // twice per frame can be very challenging. Note that the `receiver.try_recv` call is very
+        // cheap so it is better to err towards overeager checks than infrequent checks.
+
+        // the current active injector
+        let mut current_injector = injector;
+        let mut remaining_items = NUM_ITEMS;
+
+        loop {
+            match receiver.try_recv() {
+                Ok(new_injector) => {
+                    // we received a new injector so we should immediately start sending `u32`s to
+                    // it instead
+                    current_injector = new_injector;
+                    remaining_items = NUM_ITEMS;
+                }
+                Err(TryRecvError::Empty) => {
+                    if remaining_items > 0 {
+                        // we still have remaining data to be sent; continue to send it to the
+                        // picker
+                        remaining_items -= 1;
+                        current_injector.push(slow_random());
+                    } else if let Ok(new_injector) = receiver.recv() {
+                        // we have sent all of the necessary data; but we cannot simply skip this
+                        // branch or we will spin-loop and consume unnecessary CPU cycles. Instead,
+                        // we should block and wait for the next restart event since we have
+                        // nothing else to do. Once we receive the new injector, reset the state
+                        // and begin generating again.
+                        current_injector = new_injector;
+                        remaining_items = NUM_ITEMS;
+                    } else {
+                        return;
+                    }
+                }
+                Err(TryRecvError::Disconnected) => {
+                    // the channel disconnected so we can shut down this thread
+                    return;
+                }
+            }
+        }
+    });
+
+    let event_source = StdinReader::new(move |key_event| match key_event {
+        KeyEvent {
+            kind: KeyEventKind::Press,
+            modifiers: KeyModifiers::CONTROL,
+            code: KeyCode::Char('n'),
+            ..
+        } => Some(Event::Restart::<_, _>(sync_sender.clone())),
+        e => keybind_default(e),
+    });
+
+    match picker.pick_with_io(event_source, &mut stderr)? {
+        Some(num) => {
+            println!("Your favourite number is: {num}");
+            Ok(())
+        }
+        None => {
+            println!("You didn't like any of the numbers!");
+            exit(1);
+        }
+    }
+}

--- a/src/event/bind.rs
+++ b/src/event/bind.rs
@@ -15,7 +15,7 @@ use super::{Event, MatchListEvent, PromptEvent};
 /// here for flexibility to generate events of a particular type when used in situations where `A`
 /// is not the default `!`.
 #[inline]
-pub fn keybind_default<A>(key_event: KeyEvent) -> Option<Event<A>> {
+pub fn keybind_default<T, R, A>(key_event: KeyEvent) -> Option<Event<T, R, A>> {
     match key_event {
         KeyEvent {
             kind: KeyEventKind::Press,
@@ -84,10 +84,10 @@ pub fn keybind_default<A>(key_event: KeyEvent) -> Option<Event<A>> {
 }
 
 /// Convert a crossterm event into an [`Event`], mapping key events with the giving key bindings.
-pub fn convert_crossterm_event<A, F: Fn(KeyEvent) -> Option<Event<A>>>(
+pub fn convert_crossterm_event<T, R, A, F: Fn(KeyEvent) -> Option<Event<T, R, A>>>(
     ct_event: CrosstermEvent,
     keybind: F,
-) -> Option<Event<A>> {
+) -> Option<Event<T, R, A>> {
     match ct_event {
         CrosstermEvent::Key(key_event) => (keybind)(key_event),
         CrosstermEvent::Resize(_, _) => Some(Event::Redraw),

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -4,7 +4,7 @@ use crate::{
     match_list::MatchList,
     prompt::{Prompt, PromptStatus},
     util::as_u32,
-    Render,
+    Injector, Render,
 };
 
 pub struct LazyMatchList<'a, T: Send + Sync + 'static, R: Render<T>> {
@@ -19,6 +19,12 @@ impl<'a, T: Send + Sync + 'static, R: Render<T>> LazyMatchList<'a, T, R> {
             match_list,
             buffered_selection,
         }
+    }
+
+    pub fn restart(&mut self) -> Injector<T, R> {
+        self.match_list.restart();
+        self.buffered_selection = 0;
+        self.match_list.injector()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,6 +527,11 @@ impl<T: Send + Sync + 'static, R: Render<T>> Picker<T, R> {
     ///
     /// Internally, this is a call to [`Nucleo::restart`] with `clear_snapshot = true`.
     /// See the documentation for [`Nucleo::restart`] for more detail.
+    ///
+    /// This method is mainly useful for re-using the picker for multiple matches since the
+    /// internal memory buffers are preserved. To restart the picker during interactive use, see
+    /// the [`Event`] documentation or the [restart
+    /// example](https://github.com/autobib/nucleo-picker/blob/master/examples/restart.rs).
     pub fn restart(&mut self) {
         self.match_list.restart();
     }

--- a/src/match_list.rs
+++ b/src/match_list.rs
@@ -284,7 +284,7 @@ impl<T: Send + Sync + 'static, R: Render<T>> MatchList<T, R> {
     /// Clear all of the items and restart the match engine.
     pub fn restart(&mut self) {
         self.nucleo.restart(true);
-        self.reset();
+        self.update_items();
     }
 
     /// Replace the internal [`nucleo`] configuration.
@@ -449,7 +449,7 @@ impl<T: Send + Sync + 'static, R: Render<T>> MatchList<T, R> {
     }
 
     /// Reset the layout, setting the cursor to '0' and rendering the items.
-    fn reset(&mut self) -> bool {
+    pub fn reset(&mut self) -> bool {
         let buffer = self.nucleo.snapshot();
         let padding = self.padding(self.size);
         if self.selection != 0 {


### PR DESCRIPTION
This PR implements interactive restarting. In order to implement this, unfortunately the type parameters `T` and `R` had to be added to the `Event` enum, since the `Event` enum now must carry a variant which can used to send an `Injector<T, R>` back to the `Event` source. This means type inference fails a bit more easily now, and adds some boilerplate to type annotations in certain situations. However, overall, having the type parameters `T` and `R` now accessible to the `Event` enum means adding new variants in the future involving the renderer or the picker item type will be non-breaking.

The interactive restarting was otherwise quite simple to implement inside the picker (just restart, and send a new injector down the channel). However incorporating it into an application can be a bit more work. Therefore I added reasonably comprehensive examples `restart` and `restart_ext` which demonstrate how this might be done in practice and why the API has the shape that it does.