### PR TITLE
Expose renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2025-02-07
+
+### Added
+- Added method `Injector::renderer` to get a reference to the `Render` implementation internal to the picker.
+
 ## [0.8.0] - 2025-01-14
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["cli"]
 license = "MIT OR Apache-2.0"
 name = "nucleo-picker"
 repository = "https://github.com/autobib/nucleo-picker"
-version = "0.8.0"
+version = "0.8.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 by Alex Rutar
+Copyright (c) 2025 by Alex Rutar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/injector.rs
+++ b/src/injector.rs
@@ -70,6 +70,11 @@ impl<T, R: Render<T>> Injector<T, R> {
             columns[0] = self.render.render(s).as_ref().into();
         });
     }
+
+    /// Returns a reference to the renderer internal to the picker.
+    pub fn renderer(&self) -> &R {
+        &self.render
+    }
 }
 
 impl<T, R: Render<T>> Extend<T> for Injector<T, R> {


### PR DESCRIPTION
Provides a method to get a reference to the `Render` implementation internal to the picker via the `Injector`.